### PR TITLE
[WIP] Added togglability options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -246,6 +246,7 @@ export default class Ellipsis extends React.Component {
               <button
                 onClick={this.toggleOpenState}
                 className="rae__toggle-btn"
+                aria-hidden
               >
                 {isOpen ? showLessLabel : showMoreLabel}
               </button>

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Fragment } from "react";
 // import FontFaceObserver from 'font-face-observer';
 
 const SIXTY_FPS = 1000 / 60;
@@ -14,6 +14,11 @@ export default class Ellipsis extends React.Component {
       this.reflowEllipsis.bind(this),
       SIXTY_FPS
     );
+    this.state = {
+      // needsTruncation: false,
+      showHideEnabled: false,
+      isOpen: !!this.props.openByDefault,
+    };
     this.reflowIfSizeChange = this.reflowIfSizeChange.bind(this);
     this.renderEllipsisAt = this.renderEllipsisAt.bind(this);
     this.moveEllipsis = this.moveEllipsis.bind(this);
@@ -93,8 +98,10 @@ export default class Ellipsis extends React.Component {
     this.containerScrollHeight = this.containerNode.scrollHeight;
   }
 
-  shouldComponentUpdate(nextProps) {
-    return nextProps.children !== this.props.children;
+  shouldComponentUpdate(nextProps, nextState) {
+    return (
+      nextProps.children !== this.props.children || nextState !== this.nextState
+    );
   }
 
   reflowEllipsis() {
@@ -183,8 +190,25 @@ export default class Ellipsis extends React.Component {
     );
   }
 
+  toggleOpenState = () => {
+    this.setState({ isOpen: !this.state.isOpen });
+  };
+
   render() {
-    const { children, className, style } = this.props;
+    const {
+      children,
+      className,
+      style,
+      customButton,
+      showToggleButton,
+      clickToToggle,
+      showMoreText,
+      showLessText,
+    } = this.props;
+
+    const { isOpen } = this.state;
+    const showMoreLabel = showMoreText || "Show more";
+    const showLessLabel = showLessText || "Show less";
 
     if (this.offset !== undefined) {
       if (this.timer) clearTimeout(this.timer);
@@ -192,19 +216,43 @@ export default class Ellipsis extends React.Component {
     }
 
     return (
-      <div
-        ref={containerNode => {
-          this.containerNode = containerNode;
-        }}
-        className={className}
-        style={{
-          position: "relative", // needed to calculate location of child nodes
-          overflow: "hidden", // they can always override this with style if they have any niche use-cases for ellipsis and overflow: 'visible'
-          ...style
-        }}
-      >
-        {children}
-      </div>
+      <Fragment>
+        <div
+          ref={containerNode => {
+            this.containerNode = containerNode;
+          }}
+          onClick={clickToToggle && this.toggleOpenState}
+          className={className}
+          style={{
+            position: "relative", // needed to calculate location of child nodes
+            overflow: isOpen ? "visible" : "hidden",
+            height: isOpen ? "auto" : null,
+            ...style,
+          }}
+        >
+          {children}
+        </div>
+
+        {showToggleButton && (
+          <Fragment>
+            {customButton ? (
+              customButton(
+                isOpen,
+                this.toggleOpenState,
+                showMoreText,
+                showLessText
+              )
+            ) : (
+              <button
+                onClick={this.toggleOpenState}
+                className="rae__toggle-btn"
+              >
+                {isOpen ? showLessLabel : showMoreLabel}
+              </button>
+            )}
+          </Fragment>
+        )}
+      </Fragment>
     );
   }
 }


### PR DESCRIPTION
### New props **(all optional)**.

`showToggleButton`: boolean. Default: False. If true, shows an expand/collapse toggle button (can be custom render prop, see below) 

`clickTextToToggle`: boolean. Default: False. If true, clicking the text itself will toggle expand/collapse.

`openByDefault`: boolean. Default: False. If true, the full text will be rendered by default, but can be manually collapsed if 'showToggleButton' is true.

`showMoreText`: string. Default: "Show more"

`showLessText`: string. Default: "Show less"

`customButton` Function. Example syntax below. If not passed, and showToggleButton is true, a default button will be used instead.

```
<Ellipsis
  className="my-class-with-a-height"
  showToggleButton
  clickTextToToggle
  openByDefault
  showMoreText="Show some more of those awesome words"
  showLessText="Show less plz"
  customButton={(
    isOpen,
    toggleOpenState,
    showMoreText,
    showLessText
  ) => {
    return (
      <button aria-hidden  onClick={toggleOpenState} className="my-custom-class">
        {isOpen ? showLessText : showMoreText}
      </button>
    );
  }}
>
  Cowslip fuchsia lupin red-hot poker. Barberton daisy guelder rose
  blue throatwort jersey lily. Christmas rose cowbane lobster claw dog
  rose brodiaea sea holly sweet sultan. Spider orchid round-leaved
  sundew sturt's desert rose tazetta lilac safari sunset.
</Ellipsis>
```

TODO: component needs to know whether the text actually needs truncation. Then the toggle stuff needs to be hidden if not.