### PR TITLE
allow using ellipsis in react ssr stage, next.js compatibility

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -40,11 +40,6 @@ var Ellipsis = function (_React$Component) {
     _this.reflowIfSizeChange = _this.reflowIfSizeChange.bind(_this);
     _this.renderEllipsisAt = _this.renderEllipsisAt.bind(_this);
     _this.moveEllipsis = _this.moveEllipsis.bind(_this);
-    _this.ellipsisNode = document.createElement("span");
-    _this.ellipsisNode.setAttribute("aria-hidden", true);
-    _this.ellipsisNode.style.userSelect = "none"; // disable text selection. Don't care about non-standard browser prefixes.
-    _this.ellipsisNode.setAttribute("unselectable", "on"); // IE < 10 and Opera < 15 https://stackoverflow.com/a/4358620
-    _this.ellipsisNode.textContent = _this.props.ellipsis || DEFAULT_ELLIPSIS;
     _this.mutationWatcherMilliseconds = DEFAULT_MUTATION_WATCHER_MILLISECONDS;
     return _this;
   }
@@ -65,6 +60,12 @@ var Ellipsis = function (_React$Component) {
       this.containerScrollHeight = this.containerNode.scrollHeight;
       window.addEventListener("resize", this.reflowEllipsis);
       window.addEventListener("orientationchange", this.reflowEllipsis);
+
+      this.ellipsisNode = document.createElement("span");
+      this.ellipsisNode.setAttribute("aria-hidden", true);
+      this.ellipsisNode.style.userSelect = "none"; // disable text selection. Don't care about non-standard browser prefixes.
+      this.ellipsisNode.setAttribute("unselectable", "on"); // IE < 10 and Opera < 15 https://stackoverflow.com/a/4358620
+      this.ellipsisNode.textContent = this.props.ellipsis || DEFAULT_ELLIPSIS;
 
       // Fonts may load later and affect ellipsis placement.
       // This abandoned code might be useful in the future.

--- a/src/index.js
+++ b/src/index.js
@@ -17,11 +17,6 @@ export default class Ellipsis extends React.Component {
     this.reflowIfSizeChange = this.reflowIfSizeChange.bind(this);
     this.renderEllipsisAt = this.renderEllipsisAt.bind(this);
     this.moveEllipsis = this.moveEllipsis.bind(this);
-    this.ellipsisNode = document.createElement("span");
-    this.ellipsisNode.setAttribute("aria-hidden", true);
-    this.ellipsisNode.style.userSelect = "none"; // disable text selection. Don't care about non-standard browser prefixes.
-    this.ellipsisNode.setAttribute("unselectable", "on"); // IE < 10 and Opera < 15 https://stackoverflow.com/a/4358620
-    this.ellipsisNode.textContent = this.props.ellipsis || DEFAULT_ELLIPSIS;
     this.mutationWatcherMilliseconds = DEFAULT_MUTATION_WATCHER_MILLISECONDS;
   }
 
@@ -38,6 +33,12 @@ export default class Ellipsis extends React.Component {
     this.containerScrollHeight = this.containerNode.scrollHeight;
     window.addEventListener("resize", this.reflowEllipsis);
     window.addEventListener("orientationchange", this.reflowEllipsis);
+
+    this.ellipsisNode = document.createElement("span");
+    this.ellipsisNode.setAttribute("aria-hidden", true);
+    this.ellipsisNode.style.userSelect = "none"; // disable text selection. Don't care about non-standard browser prefixes.
+    this.ellipsisNode.setAttribute("unselectable", "on"); // IE < 10 and Opera < 15 https://stackoverflow.com/a/4358620
+    this.ellipsisNode.textContent = this.props.ellipsis || DEFAULT_ELLIPSIS;
 
     // Fonts may load later and affect ellipsis placement.
     // This abandoned code might be useful in the future.


### PR DESCRIPTION
Hi

Current version of the library kills server render when `Ellipsis` is added to the page. The reason is it created `span` element in the constructor, causing `document is not defined` in server-side renders. In my case it's a Next.js app that gets broken…

Since this element is not needed until component is mounted on the page, I moved that code to `componentDidMount` method, which isn't called during server render. This seems to work perfectly, no backwards incompatibility of any sort…